### PR TITLE
rgw: fixes for running rgw_create succesfully

### DIFF
--- a/srv/salt/ceph/rgw/init.sls
+++ b/srv/salt/ceph/rgw/init.sls
@@ -18,8 +18,7 @@ rgw_create:
   module.run:
     - name: ceph.rgw_create
     - kwargs: {
-        name: mds.{{ grains['host'] }},
-      }
+        name: rgw.{{ grains['host'] }}
+        }
     - require:
-      - module: rgw_prep
-
+      - module: keyring_auth_add_rgw


### PR DESCRIPTION
Couple of fixes including:
- we create a rgw named as `rgw.host`
- require keyring to be added before calling create

Signed-off-by: Abhishek Lekshmanan abhishek@suse.com
