### PR TITLE
fix mds creation

### DIFF
--- a/srv/salt/ceph/mds/init.sls
+++ b/srv/salt/ceph/mds/init.sls
@@ -20,5 +20,5 @@ mds_create:
     - kwargs: {
         name: mds.{{ grains['host'] }},
         port: 6800,
-        addr: {{ salt['network.interfaces']()[pillar.public_interface]['inet'][0]['address'] }} 
+        addr: {{ salt['pillar.get']('public_address') }}
       }


### PR DESCRIPTION
state file mds/init.sls still relied on public_interface mechanism. This
fix corresponds to the newer public_address scheme in the pillar.

Signed-off-by: Jan Fajerski jfajerski@suse.com
